### PR TITLE
feat: auto-scroll during drag interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunsama/event-calendar",
-  "version": "0.13.0",
+  "version": "0.12.0",
   "description": "Event calendar.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunsama/event-calendar",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Event calendar.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/components/background-hours-content.tsx
+++ b/src/components/background-hours-content.tsx
@@ -1,10 +1,14 @@
 import { memo, type RefObject, useContext } from "react";
-import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import Animated, {
+  useAnimatedStyle,
+  useDerivedValue,
+} from "react-native-reanimated";
 import { StyleSheet } from "react-native";
 import { ConfigProvider } from "../utils/globals";
 import { PrefabHour } from "../types";
 import useLongPressNewEvent from "../hooks/use-long-press-new-event";
 import { GestureDetector } from "react-native-gesture-handler";
+import useAutoScroll from "../hooks/use-auto-scroll";
 
 type BackgroundHoursContentProps = {
   hours: PrefabHour[];
@@ -13,13 +17,37 @@ type BackgroundHoursContentProps = {
 
 const BackgroundHoursContent = memo(
   ({ refNewEvent, hours }: BackgroundHoursContentProps) => {
-    const { theme, zoomLevel } = useContext(ConfigProvider);
+    const {
+      theme,
+      zoomLevel,
+      createY,
+      maximumHour,
+      scrollY,
+      scrollRef,
+      scrollViewHeight,
+    } = useContext(ConfigProvider);
 
     const styleHourSize = useAnimatedStyle(() => {
       return { height: zoomLevel.value * 60 };
     }, []);
 
-    const longPressNewEvent = useLongPressNewEvent(refNewEvent);
+    const { gesture: longPressNewEvent, isDragging } =
+      useLongPressNewEvent(refNewEvent);
+
+    const bottomEdgeY = useDerivedValue(
+      () => createY.value + zoomLevel.value * 60
+    );
+
+    useAutoScroll({
+      scrollRef,
+      scrollY,
+      scrollViewHeight,
+      maximumHour,
+      topEdgeY: createY,
+      bottomEdgeY,
+      isActive: isDragging,
+      positionY: createY,
+    });
 
     return (
       <GestureDetector gesture={longPressNewEvent}>

--- a/src/components/background-hours-layout.tsx
+++ b/src/components/background-hours-layout.tsx
@@ -19,7 +19,7 @@ const BackgroundHoursLayout = memo(
       return { height: zoomLevel.value * 60 };
     }, []);
 
-    const longPressNewEvent = useLongPressNewEvent(refNewEvent);
+    const { gesture: longPressNewEvent } = useLongPressNewEvent(refNewEvent);
 
     return (
       <GestureDetector gesture={longPressNewEvent}>

--- a/src/components/drag-bar.tsx
+++ b/src/components/drag-bar.tsx
@@ -1,8 +1,15 @@
-import Animated, { SharedValue, useSharedValue } from "react-native-reanimated";
-import { ReactNode, type RefObject, useMemo } from "react";
+import Animated, {
+  SharedValue,
+  useDerivedValue,
+  useSharedValue,
+} from "react-native-reanimated";
+import { ReactNode, type RefObject, useContext, useMemo } from "react";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { StyleSheet } from "react-native";
 import type { CalendarEvent } from "src/types";
+import { useIsEditing } from "../hooks/use-is-editing";
+import { ConfigProvider } from "../utils/globals";
+import useAutoScroll from "../hooks/use-auto-scroll";
 
 type DragBarProps<T extends CalendarEvent> = {
   top?: SharedValue<number>;
@@ -103,20 +110,47 @@ const DragBar = <T extends CalendarEvent>({
   zoomLevel,
   maximumHour,
 }: DragBarProps<T>) => {
+  const { currentY } = useIsEditing();
+  const { scrollRef, scrollY, scrollViewHeight } = useContext(ConfigProvider);
+
   const startY = useSharedValue(0);
+  const isDragging = useSharedValue(false);
+  const autoScrollOffset = useSharedValue(0);
+
+  const dragEdge = useDerivedValue(() =>
+    top ? top.value : currentY.value + height.value
+  );
+
+  useAutoScroll({
+    scrollRef,
+    scrollY,
+    scrollViewHeight,
+    maximumHour,
+    topEdgeY: dragEdge,
+    bottomEdgeY: dragEdge,
+    isActive: isDragging,
+    autoScrollOffset,
+    positionY: top || undefined,
+    heightValue: height,
+    invertHeight: !!top,
+  });
 
   const gesturePan = Gesture.Pan()
     .blocksExternalGesture(refMainContainer)
     .onStart(() => {
       startY.value = top ? top.value : height.value;
+      autoScrollOffset.value = 0;
+      isDragging.value = true;
     })
     .onUpdate(({ translationY }) => {
+      const effectiveTranslation = translationY + autoScrollOffset.value;
+
       if (top) {
         handleTopDrag(
           top,
           fiveMinuteInterval,
           startY,
-          translationY,
+          effectiveTranslation,
           zoomLevel,
           maximumHour,
           height
@@ -128,10 +162,13 @@ const DragBar = <T extends CalendarEvent>({
       handleBottomDrag(
         fiveMinuteInterval,
         startY,
-        translationY,
+        effectiveTranslation,
         zoomLevel,
         height
       );
+    })
+    .onFinalize(() => {
+      isDragging.value = false;
     });
 
   const styleDragBar = useMemo(

--- a/src/components/edit-event-container.tsx
+++ b/src/components/edit-event-container.tsx
@@ -17,6 +17,7 @@ import Animated, {
   useDerivedValue,
   useSharedValue,
 } from "react-native-reanimated";
+import useAutoScroll from "../hooks/use-auto-scroll";
 import { type CalendarEvent, EventExtend } from "../types";
 import gesturePan from "../utils/pan-edit-event-gesture";
 import DragBar from "../components/drag-bar";
@@ -31,6 +32,8 @@ const EditEventContainer = memo(
   ({ refNewEvent }: EditEventContainerProps) => {
     const {
       currentY,
+      isDragging,
+      autoScrollOffset,
       isEditing: editingEvent,
       setIsEditing,
       updateEditing,
@@ -44,8 +47,24 @@ const EditEventContainer = memo(
       renderEvent,
       timezone,
       dayDate,
+      scrollY,
+      scrollRef,
+      scrollViewHeight,
     } = useContext(ConfigProvider);
     const height = useSharedValue(0);
+    const bottomEdgeY = useDerivedValue(() => currentY.value + height.value);
+
+    useAutoScroll({
+      scrollRef,
+      scrollY,
+      scrollViewHeight,
+      maximumHour,
+      topEdgeY: currentY,
+      bottomEdgeY,
+      isActive: isDragging,
+      autoScrollOffset,
+      positionY: currentY,
+    });
 
     const calculateHeight = useCallback(
       (event: CalendarEvent, zoom: number) => {
@@ -202,7 +221,11 @@ const EditEventContainer = memo(
             maximumHour,
             height,
             refNewEvent,
-            fiveMinuteInterval
+            fiveMinuteInterval,
+            undefined,
+            undefined,
+            isDragging,
+            autoScrollOffset
           ).withRef(refMainContainer)
         )}
       >

--- a/src/components/timed-event-container.tsx
+++ b/src/components/timed-event-container.tsx
@@ -34,7 +34,8 @@ const TimedEventContainerInner = <T extends CalendarEvent>({
   layout,
   refNewEvent,
 }: TimedEventContainerProps<T>) => {
-  const { currentY, setIsEditing, isEditing } = useIsEditing();
+  const { currentY, isDragging, autoScrollOffset, setIsEditing, isEditing } =
+    useIsEditing();
   const {
     onPressEvent,
     maximumHour,
@@ -96,7 +97,9 @@ const TimedEventContainerInner = <T extends CalendarEvent>({
       refNewEvent,
       fiveMinuteInterval,
       isEditing,
-      startEditing
+      startEditing,
+      isDragging,
+      autoScrollOffset
     ).activateAfterLongPress(500)
   );
 

--- a/src/hooks/use-auto-scroll.ts
+++ b/src/hooks/use-auto-scroll.ts
@@ -1,0 +1,88 @@
+import Animated, {
+  type AnimatedRef,
+  type SharedValue,
+  scrollTo,
+  useFrameCallback,
+} from "react-native-reanimated";
+
+const AUTO_SCROLL_TOP_THRESHOLD = 80;
+const AUTO_SCROLL_BOTTOM_THRESHOLD = 150;
+const AUTO_SCROLL_MAX_SPEED = 8;
+
+type AutoScrollParams = {
+  scrollRef: AnimatedRef<Animated.ScrollView>;
+  scrollY: SharedValue<number>;
+  scrollViewHeight: SharedValue<number>;
+  maximumHour: SharedValue<number>;
+  topEdgeY: SharedValue<number>;
+  bottomEdgeY: SharedValue<number>;
+  isActive: SharedValue<boolean>;
+  autoScrollOffset?: SharedValue<number>;
+  positionY?: SharedValue<number>;
+  heightValue?: SharedValue<number>;
+  invertHeight?: boolean;
+};
+
+export default function useAutoScroll({
+  scrollRef,
+  scrollY,
+  scrollViewHeight,
+  maximumHour,
+  topEdgeY,
+  bottomEdgeY,
+  isActive,
+  autoScrollOffset,
+  positionY,
+  heightValue,
+  invertHeight,
+}: AutoScrollParams) {
+  useFrameCallback(() => {
+    if (!isActive.value) return;
+
+    const viewportTop = scrollY.value;
+    const viewportBottom = scrollY.value + scrollViewHeight.value;
+
+    let scrollDelta = 0;
+
+    const distFromTop = topEdgeY.value - viewportTop;
+    const distFromBottom = viewportBottom - bottomEdgeY.value;
+
+    if (
+      distFromTop < AUTO_SCROLL_TOP_THRESHOLD &&
+      distFromTop <= distFromBottom
+    ) {
+      const ratio = Math.max(0, 1 - distFromTop / AUTO_SCROLL_TOP_THRESHOLD);
+      scrollDelta = -ratio * AUTO_SCROLL_MAX_SPEED;
+    } else if (distFromBottom < AUTO_SCROLL_BOTTOM_THRESHOLD) {
+      const ratio = Math.max(
+        0,
+        1 - distFromBottom / AUTO_SCROLL_BOTTOM_THRESHOLD
+      );
+      scrollDelta = ratio * AUTO_SCROLL_MAX_SPEED;
+    }
+
+    if (scrollDelta === 0) return;
+
+    const maxScrollY = Math.max(0, maximumHour.value - scrollViewHeight.value);
+    const newScrollY = Math.min(
+      maxScrollY,
+      Math.max(0, scrollY.value + scrollDelta)
+    );
+    const actualDelta = newScrollY - scrollY.value;
+
+    if (Math.abs(actualDelta) < 0.5) return;
+
+    scrollTo(scrollRef, 0, newScrollY, false);
+    scrollY.value = newScrollY;
+
+    if (positionY) {
+      positionY.value += actualDelta;
+    }
+    if (autoScrollOffset) {
+      autoScrollOffset.value += actualDelta;
+    }
+    if (heightValue) {
+      heightValue.value += invertHeight ? -actualDelta : actualDelta;
+    }
+  });
+}

--- a/src/hooks/use-is-editing.tsx
+++ b/src/hooks/use-is-editing.tsx
@@ -23,6 +23,8 @@ interface IsEditingType<T extends CalendarEvent = CalendarEvent> {
   isEditing: null | PartDayEventLayoutType<T>;
   updateEditing: (top: number, height: number) => void;
   currentY: SharedValue<number>;
+  isDragging: SharedValue<boolean>;
+  autoScrollOffset: SharedValue<number>;
   setIsEditing: (
     newValue: PartDayEventLayoutType<T> | null,
     updatedTimes?: {
@@ -58,6 +60,8 @@ const IsEditingProviderInner = <T extends CalendarEvent>(
   const [isEditing, baseSetIsEditing] =
     useState<null | PartDayEventLayoutType<T>>(null);
   const currentY = useSharedValue(0);
+  const isDragging = useSharedValue(false);
+  const autoScrollOffset = useSharedValue(0);
 
   const updateEditing = debounce(
     (start: number, end: number) => {
@@ -153,7 +157,15 @@ const IsEditingProviderInner = <T extends CalendarEvent>(
 
   return (
     <IsEditing.Provider
-      value={{ currentY, isEditing, setIsEditing, updateEditing, refMethods }}
+      value={{
+        currentY,
+        isDragging,
+        autoScrollOffset,
+        isEditing,
+        setIsEditing,
+        updateEditing,
+        refMethods,
+      }}
     >
       {children}
     </IsEditing.Provider>

--- a/src/hooks/use-long-press-new-event.ts
+++ b/src/hooks/use-long-press-new-event.ts
@@ -16,7 +16,7 @@ export default function useLongPressNewEvent(refNewEvent: RefObject<any>) {
   const { isEditing } = useIsEditing();
   const isDragging = useSharedValue(false);
 
-  return Gesture.LongPress()
+  const gesture = Gesture.LongPress()
     .enabled(canCreateEvents && !isEditing)
     .withRef(refNewEvent as any)
     .numberOfPointers(1)
@@ -99,5 +99,12 @@ export default function useLongPressNewEvent(refNewEvent: RefObject<any>) {
         hour,
         minute,
       });
+    })
+    .onFinalize(() => {
+      "worklet";
+
+      isDragging.value = false;
     });
+
+  return { gesture, isDragging };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -241,6 +241,9 @@ function EventCalendarContentInner<T extends CalendarEvent>(
           updateLocalStateAfterEdit,
           theme,
           initialEventEdit,
+          scrollY,
+          scrollRef: refScrollView,
+          scrollViewHeight,
         }}
       >
         <AllDayEvents />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 import { Moment } from "moment-timezone";
 import { TextStyle, ViewStyle } from "react-native";
-import { DerivedValue, SharedValue } from "react-native-reanimated";
+import Animated, {
+  type AnimatedRef,
+  DerivedValue,
+  SharedValue,
+} from "react-native-reanimated";
 import { ReactNode } from "react";
 
 export type CalendarEvent = {
@@ -136,6 +140,9 @@ export interface Config<T extends CalendarEvent> {
   updateLocalStateAfterEdit: boolean;
   extraTimedComponents?: (zoomLevel: SharedValue<number>) => ReactNode;
   onZoomChange?: (zoomLevel: number) => void;
+  scrollY: SharedValue<number>;
+  scrollRef: AnimatedRef<Animated.ScrollView>;
+  scrollViewHeight: SharedValue<number>;
 }
 
 export type PrefabHour = {

--- a/src/utils/pan-edit-event-gesture.ts
+++ b/src/utils/pan-edit-event-gesture.ts
@@ -13,7 +13,9 @@ const gesturePan = <T extends CalendarEvent>(
   refNewEvent: RefObject<any>,
   fiveMinuteInterval?: boolean,
   isEditing?: null | PartDayEventLayoutType<T>,
-  startEditing?: () => void
+  startEditing?: () => void,
+  isDragging?: SharedValue<boolean>,
+  autoScrollOffset?: SharedValue<number>
 ) =>
   Gesture.Pan()
     .blocksExternalGesture(refNewEvent)
@@ -29,8 +31,12 @@ const gesturePan = <T extends CalendarEvent>(
       }
 
       startY.value = top.value;
+      if (isDragging) isDragging.value = true;
+      if (autoScrollOffset) autoScrollOffset.value = 0;
     })
     .onUpdate(({ translationY }) => {
+      const effectiveTranslation =
+        translationY + (autoScrollOffset ? autoScrollOffset.value : 0);
       let freshUpdatedStartTime;
 
       if (fiveMinuteInterval) {
@@ -39,7 +45,7 @@ const gesturePan = <T extends CalendarEvent>(
         freshUpdatedStartTime = Math.max(
           0,
           startY.value +
-            Math.floor(translationY / zoomLevel.value / 5) *
+            Math.floor(effectiveTranslation / zoomLevel.value / 5) *
               (zoomLevel.value * 5)
         );
       } else {
@@ -48,7 +54,7 @@ const gesturePan = <T extends CalendarEvent>(
         freshUpdatedStartTime = Math.max(
           0,
           startY.value +
-            Math.floor(translationY / zoomLevel.value) * zoomLevel.value
+            Math.floor(effectiveTranslation / zoomLevel.value) * zoomLevel.value
         );
       }
 
@@ -59,6 +65,9 @@ const gesturePan = <T extends CalendarEvent>(
       }
 
       currentY.value = freshUpdatedStartTime;
+    })
+    .onFinalize(() => {
+      if (isDragging) isDragging.value = false;
     });
 
 export default gesturePan;


### PR DESCRIPTION
## Summary
- Adds auto-scrolling when dragging events (edit, resize, or create) near the top/bottom edges of the calendar viewport
- Scroll speed scales proportionally to proximity to the edge (up to 8px/frame)
- Bottom threshold is larger (150px) than top (80px) to account for finger/hand occlusion
- Works across all drag modes: body pan, top/bottom drag bars, and new event creation

## Test plan
- [x] Long-press to create a new event near the bottom of the viewport — calendar should scroll down
- [x] Edit an existing event and drag it toward the top edge — calendar should scroll up
- [x] Use the bottom drag bar to extend an event past the viewport bottom — calendar should scroll down
- [x] Use the top drag bar to extend an event past the viewport top — calendar should scroll up
- [x] Verify scroll speed increases as the drag point gets closer to the edge
- [x] Verify auto-scroll stops immediately when the drag ends
- [x] Verify 5-minute interval snapping still works correctly during auto-scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)