### PR TITLE
fix: make auto-scroll speed consistent across platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunsama/event-calendar",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Event calendar.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/hooks/use-auto-scroll.ts
+++ b/src/hooks/use-auto-scroll.ts
@@ -7,7 +7,7 @@ import Animated, {
 
 const AUTO_SCROLL_TOP_THRESHOLD = 80;
 const AUTO_SCROLL_BOTTOM_THRESHOLD = 150;
-const AUTO_SCROLL_MAX_SPEED = 8;
+const AUTO_SCROLL_MAX_SPEED_PPS = 480;
 
 type AutoScrollParams = {
   scrollRef: AnimatedRef<Animated.ScrollView>;
@@ -36,8 +36,10 @@ export default function useAutoScroll({
   heightValue,
   invertHeight,
 }: AutoScrollParams) {
-  useFrameCallback(() => {
+  useFrameCallback((frameInfo) => {
     if (!isActive.value) return;
+
+    const dt = (frameInfo.timeSincePreviousFrame ?? 16) / 1000;
 
     const viewportTop = scrollY.value;
     const viewportBottom = scrollY.value + scrollViewHeight.value;
@@ -52,13 +54,13 @@ export default function useAutoScroll({
       distFromTop <= distFromBottom
     ) {
       const ratio = Math.max(0, 1 - distFromTop / AUTO_SCROLL_TOP_THRESHOLD);
-      scrollDelta = -ratio * AUTO_SCROLL_MAX_SPEED;
+      scrollDelta = -ratio * AUTO_SCROLL_MAX_SPEED_PPS * dt;
     } else if (distFromBottom < AUTO_SCROLL_BOTTOM_THRESHOLD) {
       const ratio = Math.max(
         0,
         1 - distFromBottom / AUTO_SCROLL_BOTTOM_THRESHOLD
       );
-      scrollDelta = ratio * AUTO_SCROLL_MAX_SPEED;
+      scrollDelta = ratio * AUTO_SCROLL_MAX_SPEED_PPS * dt;
     }
 
     if (scrollDelta === 0) return;


### PR DESCRIPTION
## Summary
- Auto-scroll during drag was too fast on Android because speed was defined as pixels-per-frame (8px), which varies with frame rate
- Switched to time-based speed (480px/s) using `timeSincePreviousFrame` so scroll behavior is identical on iOS and Android

## Test plan
- [x] Verified on iOS — scroll speed unchanged
- [x] Verify on Android — scroll speed should now match iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)