### PR TITLE
fix: stabilize auto-scroll and pinch-to-zoom on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunsama/event-calendar",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Event calendar.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/components/zoom-provider.tsx
+++ b/src/components/zoom-provider.tsx
@@ -7,7 +7,7 @@ import Animated, {
   useSharedValue,
 } from "react-native-reanimated";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { ConfigProvider } from "../utils/globals";
 import { StyleSheet } from "react-native";
 import doubleTapGesture from "../utils/double-tap-reset-zoom-gesture";
@@ -20,7 +20,9 @@ type ZoomProviderProps = {
 };
 
 // This fraction determines how quickly zoom grows
-const fraction = 0.1;
+const fraction = 0.5;
+// Minimum zoom change to commit — reduces cascading layout recalculations
+const ZOOM_STEP = 0.005;
 
 export default function ZoomProvider({
   children,
@@ -36,35 +38,35 @@ export default function ZoomProvider({
     maximumHour,
     onZoomChange,
   } = useContext(ConfigProvider);
-  const previewScale = useSharedValue(-1);
-
-  useEffect(() => {
-    previewScale.value = zoomLevel.get();
-  }, [zoomLevel, previewScale]);
+  const previewScale = useSharedValue(zoomLevel.get());
+  const focalTime = useSharedValue(0);
+  const screenFocalY = useSharedValue(0);
 
   const pinchGesture = Gesture.Pinch()
+    .onStart((event) => {
+      "worklet";
+      previewScale.value = zoomLevel.value;
+      focalTime.value = event.focalY / zoomLevel.value;
+      screenFocalY.value = event.focalY - scrollY.value;
+    })
     .onUpdate((event) => {
       "worklet";
 
-      const oldZoom = zoomLevel.value;
-      const newScale = previewScale.value * (1 + fraction * (event.scale - 1));
-      const newZoom = Math.min(maxZoomLevel, Math.max(minZoomLevel, newScale));
+      const rawScale = previewScale.value * (1 + fraction * (event.scale - 1));
+      const clamped = Math.min(maxZoomLevel, Math.max(minZoomLevel, rawScale));
+      const newZoom = Math.round(clamped / ZOOM_STEP) * ZOOM_STEP;
 
-      if (newZoom !== oldZoom) {
-        const ratio = newZoom / oldZoom;
-        const viewportFocalY = event.focalY - scrollY.value;
-        const maxScrollY = newZoom * 1440 - scrollViewHeight.value;
-        const newScrollY = Math.min(
-          Math.max(0, maxScrollY),
-          Math.max(0, (scrollY.value + viewportFocalY) * ratio - viewportFocalY)
-        );
+      if (newZoom === zoomLevel.value) return;
 
-        scrollTo(scrollRef, 0, newScrollY, false);
-        scrollY.value = newScrollY;
-      }
+      const maxScrollY = newZoom * 1440 - scrollViewHeight.value;
+      const newScrollY = Math.min(
+        Math.max(0, maxScrollY),
+        Math.max(0, focalTime.value * newZoom - screenFocalY.value)
+      );
 
+      scrollTo(scrollRef, 0, newScrollY, false);
+      scrollY.value = newScrollY;
       zoomLevel.value = newZoom;
-      previewScale.value = newZoom;
     })
     .onEnd(() => {
       if (onZoomChange) {

--- a/src/hooks/use-auto-scroll.ts
+++ b/src/hooks/use-auto-scroll.ts
@@ -39,7 +39,7 @@ export default function useAutoScroll({
   useFrameCallback((frameInfo) => {
     if (!isActive.value) return;
 
-    const dt = (frameInfo.timeSincePreviousFrame ?? 16) / 1000;
+    const dt = Math.min(frameInfo.timeSincePreviousFrame ?? 16, 64) / 1000;
 
     const viewportTop = scrollY.value;
     const viewportBottom = scrollY.value + scrollViewHeight.value;
@@ -53,12 +53,15 @@ export default function useAutoScroll({
       distFromTop < AUTO_SCROLL_TOP_THRESHOLD &&
       distFromTop <= distFromBottom
     ) {
-      const ratio = Math.max(0, 1 - distFromTop / AUTO_SCROLL_TOP_THRESHOLD);
+      const ratio = Math.min(
+        1,
+        Math.max(0, 1 - distFromTop / AUTO_SCROLL_TOP_THRESHOLD)
+      );
       scrollDelta = -ratio * AUTO_SCROLL_MAX_SPEED_PPS * dt;
     } else if (distFromBottom < AUTO_SCROLL_BOTTOM_THRESHOLD) {
-      const ratio = Math.max(
-        0,
-        1 - distFromBottom / AUTO_SCROLL_BOTTOM_THRESHOLD
+      const ratio = Math.min(
+        1,
+        Math.max(0, 1 - distFromBottom / AUTO_SCROLL_BOTTOM_THRESHOLD)
       );
       scrollDelta = ratio * AUTO_SCROLL_MAX_SPEED_PPS * dt;
     }


### PR DESCRIPTION
## Summary
- **Auto-scroll**: clamp speed ratio to `[0, 1]` so dragging an event past the viewport edge can't cause runaway scroll speed, and cap frame delta at 64 ms to absorb Android frame drops
- **Pinch-to-zoom**: replace compounding scale formula with a linear response, lock the focal point to a stable time coordinate so the view doesn't stutter, and quantize zoom steps to reduce cascading layout recalculations

## Test plan
- [ ] Android: drag an event quickly past the top/bottom edge — auto-scroll should stay smooth and capped
- [ ] Android + iOS: pinch to zoom — should feel controlled, not exponentially accelerating
- [ ] Pinch zoom keeps the focal calendar time centered on screen
- [ ] Double-tap to reset zoom still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)